### PR TITLE
Make printed tables easier to understand

### DIFF
--- a/lib/ddmetrics/table.rb
+++ b/lib/ddmetrics/table.rb
@@ -2,8 +2,9 @@
 
 module DDMetrics
   class Table
-    def initialize(rows)
+    def initialize(rows, num_headers: 1)
       @rows = rows
+      @num_headers = num_headers
     end
 
     def to_s
@@ -11,8 +12,13 @@ module DDMetrics
       column_lengths = columns.map { |c| c.map(&:size).max }
 
       [].tap do |lines|
+        # header
         lines << row_to_s(@rows[0], column_lengths)
+
+        # separator
         lines << separator(column_lengths)
+
+        # body
         rows = sort_rows(@rows.drop(1))
         lines.concat(rows.map { |r| row_to_s(r, column_lengths) })
       end.join("\n")
@@ -26,14 +32,14 @@ module DDMetrics
 
     def row_to_s(row, column_lengths)
       values = row.zip(column_lengths).map { |text, length| text.rjust(length) }
-      values[0] + ' │ ' + values[1..-1].join('   ')
+      values.take(@num_headers).join('   ') + ' │ ' + values.drop(@num_headers).join('   ')
     end
 
     def separator(column_lengths)
       (+'').tap do |s|
-        s << '─' * column_lengths[0]
+        s << column_lengths.take(@num_headers).map { |l| '─' * l }.join('───')
         s << '─┼─'
-        s << column_lengths[1..-1].map { |l| '─' * l }.join('───')
+        s << column_lengths.drop(@num_headers).map { |l| '─' * l }.join('───')
       end
     end
   end

--- a/spec/ddmetrics/counter_spec.rb
+++ b/spec/ddmetrics/counter_spec.rb
@@ -97,10 +97,10 @@ describe DDMetrics::Counter do
 
     it 'returns table' do
       expected = <<~TABLE
-                    │ count
-        ────────────┼──────
-         filter=erb │     2
-        filter=haml │     1
+        filter │ count
+        ───────┼──────
+           erb │     2
+          haml │     1
       TABLE
 
       expect(subject.strip).to eq(expected.strip)


### PR DESCRIPTION
Before:

```
            │ count    min    .50    .90    .95    max    tot
────────────┼────────────────────────────────────────────────
 filter=erb │     2   2.10   3.10   3.90   4.00   4.10   6.20
filter=haml │     1   5.30   5.30   5.30   5.30   5.30   5.30
```

After:

```
filter │ count    min    .50    .90    .95    max    tot
───────┼────────────────────────────────────────────────
   erb │     2   2.10   3.10   3.90   4.00   4.10   6.20
  haml │     1   5.30   5.30   5.30   5.30   5.30   5.30
```

Before:

```
                       │ count    min    .50    .90    .95    max    tot
───────────────────────┼────────────────────────────────────────────────
 filter=erb stage=post │     1   1.20   1.20   1.20   1.20   1.20   1.20
  filter=erb stage=pre │     2   2.10   3.10   3.90   4.00   4.10   6.20
filter=haml stage=post │     1   5.30   5.30   5.30   5.30   5.30   5.30
```

After:

```
filter   stage │ count    min    .50    .90    .95    max    tot
───────────────┼────────────────────────────────────────────────
   erb     pre │     2   2.10   3.10   3.90   4.00   4.10   6.20
   erb    post │     1   1.20   1.20   1.20   1.20   1.20   1.20
  haml    post │     1   5.30   5.30   5.30   5.30   5.30   5.30
```
