### PR TITLE
Use monotonic clock for time measurement

### DIFF
--- a/lib/ddmetrics/stopwatch.rb
+++ b/lib/ddmetrics/stopwatch.rb
@@ -2,6 +2,8 @@
 
 module DDMetrics
   class Stopwatch
+    NANOS_PER_SECOND = 1_000_000_000
+
     class AlreadyRunningError < StandardError
       def message
         'Cannot start, because stopwatch is already running'
@@ -21,27 +23,27 @@ module DDMetrics
     end
 
     def initialize
-      @duration = 0.0
+      @duration = 0
       @last_start = nil
     end
 
     def start
       raise AlreadyRunningError if running?
 
-      @last_start = Time.now
+      @last_start = nanos_now
     end
 
     def stop
       raise NotRunningError unless running?
 
-      @duration += (Time.now - @last_start)
+      @duration += (nanos_now - @last_start)
       @last_start = nil
     end
 
     def duration
       raise StillRunningError if running?
 
-      @duration
+      @duration.to_f / NANOS_PER_SECOND
     end
 
     def running?
@@ -50,6 +52,12 @@ module DDMetrics
 
     def stopped?
       !running?
+    end
+
+    private
+
+    def nanos_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
     end
   end
 end

--- a/spec/ddmetrics/stopwatch_spec.rb
+++ b/spec/ddmetrics/stopwatch_spec.rb
@@ -10,29 +10,23 @@ describe DDMetrics::Stopwatch do
   end
 
   it 'records correct duration after start+stop' do
-    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
     stopwatch.start
-
-    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
+    sleep 0.1
     stopwatch.stop
 
-    expect(stopwatch.duration).to eq(1.0)
+    expect(stopwatch.duration).to be_within(0.01).of(0.1)
   end
 
   it 'records correct duration after start+stop+start+stop' do
-    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 0))
     stopwatch.start
-
-    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 1))
+    sleep 0.1
+    stopwatch.stop
+    sleep 0.1
+    stopwatch.start
+    sleep 0.1
     stopwatch.stop
 
-    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 3))
-    stopwatch.start
-
-    Timecop.freeze(Time.local(2008, 9, 1, 10, 5, 6))
-    stopwatch.stop
-
-    expect(stopwatch.duration).to eq(1.0 + 3.0)
+    expect(stopwatch.duration).to be_within(0.02).of(0.2)
   end
 
   it 'errors when stopping when not started' do


### PR DESCRIPTION
`Time.now` is not great for time measurement, because it can jump back and forth (e.g. if the system clock is adjusted by NTP, or manually changed). `CLOCK_MONOTONIC` avoids this problem.