### PR TITLE
WIP: Use TTY::Table to render table

### DIFF
--- a/ddmetrics.gemspec
+++ b/ddmetrics.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
+
+  spec.add_runtime_dependency('tty-table', '~> 0.10')
 end

--- a/lib/ddmetrics/table.rb
+++ b/lib/ddmetrics/table.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'tty-table'
+
 module DDMetrics
   class Table
     def initialize(rows, num_headers: 1)
@@ -8,39 +10,14 @@ module DDMetrics
     end
 
     def to_s
-      columns = @rows.transpose
-      column_lengths = columns.map { |c| c.map(&:size).max }
-
-      [].tap do |lines|
-        # header
-        lines << row_to_s(@rows[0], column_lengths)
-
-        # separator
-        lines << separator(column_lengths)
-
-        # body
-        rows = sort_rows(@rows.drop(1))
-        lines.concat(rows.map { |r| row_to_s(r, column_lengths) })
-      end.join("\n")
+      table = TTY::Table.new(header: @rows[0], rows: sort_rows(@rows.drop(1)))
+      table.render(:unicode, padding: [0, 1, 0, 1])
     end
 
     private
 
     def sort_rows(rows)
       rows.sort_by { |r| r.first.downcase }
-    end
-
-    def row_to_s(row, column_lengths)
-      values = row.zip(column_lengths).map { |text, length| text.rjust(length) }
-      values.take(@num_headers).join('   ') + ' │ ' + values.drop(@num_headers).join('   ')
-    end
-
-    def separator(column_lengths)
-      (+'').tap do |s|
-        s << column_lengths.take(@num_headers).map { |l| '─' * l }.join('───')
-        s << '─┼─'
-        s << column_lengths.drop(@num_headers).map { |l| '─' * l }.join('───')
-      end
     end
   end
 end


### PR DESCRIPTION
The output of [TTY::Table](https://github.com/piotrmurach/tty-table) is slightly different from what it was before:

<img width="525" alt="Screenshot 2019-04-08 at 18 43 09" src="https://user-images.githubusercontent.com/6269/55741725-3e327380-5a2e-11e9-8005-59c5dce2b831.png">

I like ddmetrics’ original minimal style, but perhaps that can be contributed back some way or another to TTY::Table.