### PR TITLE
Add Stopwatch#run

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,25 @@ puts "That took #{stopwatch.duration}s."
 # Output: That took 2.012879s.
 ```
 
+You can use `#run` with a block for convenience:
+
+```ruby
+stopwatch.run do
+  sleep 1
+end
+```
+
+`#run` will return the value of the block:
+
+```ruby
+result = stopwatch.run do
+  sleep 1
+  'Donkey'
+end
+puts result
+# Output: Donkey
+```
+
 You can query whether or not a stopwatch is running using `#running?`; `#stopped?` is the opposite of `#running?`.
 
 ## Development

--- a/lib/ddmetrics/stopwatch.rb
+++ b/lib/ddmetrics/stopwatch.rb
@@ -27,6 +27,13 @@ module DDMetrics
       @last_start = nil
     end
 
+    def run
+      start
+      yield
+    ensure
+      stop
+    end
+
     def start
       raise AlreadyRunningError if running?
 

--- a/spec/ddmetrics/stopwatch_spec.rb
+++ b/spec/ddmetrics/stopwatch_spec.rb
@@ -29,6 +29,34 @@ describe DDMetrics::Stopwatch do
     expect(stopwatch.duration).to be_within(0.02).of(0.2)
   end
 
+  it 'records correct duration with single #run call' do
+    stopwatch.run do
+      sleep 0.1
+    end
+
+    expect(stopwatch.duration).to be_within(0.01).of(0.1)
+  end
+
+  it 'records correct duration with multiple #run calls' do
+    stopwatch.run do
+      sleep 0.1
+    end
+    stopwatch.run do
+      sleep 0.2
+    end
+
+    expect(stopwatch.duration).to be_within(0.03).of(0.3)
+  end
+
+  it 'returns the right value from a #run call' do
+    result = stopwatch.run do
+      sleep 0.1
+      'donkey'
+    end
+
+    expect(result).to eq('donkey')
+  end
+
   it 'errors when stopping when not started' do
     expect { stopwatch.stop }
       .to raise_error(


### PR DESCRIPTION
This adds `Stopwatch#run` for convenience:

```ruby
stopwatch.run do
  sleep 1
end
```

Same as this:

```ruby
stopwatch.start
sleep 1
stopwatch.end
```

